### PR TITLE
lint fixes: compatibility for deprecated apis

### DIFF
--- a/TV-Browser/src/org/tvbrowser/settings/PreferenceColorActivated.java
+++ b/TV-Browser/src/org/tvbrowser/settings/PreferenceColorActivated.java
@@ -8,6 +8,7 @@ import org.tvbrowser.view.ColorView;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.preference.DialogPreference;
+import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
@@ -59,7 +60,7 @@ public class PreferenceColorActivated extends DialogPreference {
         }
         else {
           values[0] = 1;
-          values[1] = context.getResources().getColor(resId);
+          values[1] = ContextCompat.getColor(context, resId);
         }
                
         mActivated = values[0] == 1;

--- a/TV-Browser/src/org/tvbrowser/settings/SettingConstants.java
+++ b/TV-Browser/src/org/tvbrowser/settings/SettingConstants.java
@@ -37,6 +37,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.GradientDrawable.Orientation;
 import android.graphics.drawable.LayerDrawable;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.util.SparseArray;
 
 public class SettingConstants {
@@ -283,7 +284,7 @@ public class SettingConstants {
     LayerDrawable logo = new LayerDrawable(new Drawable[] {logo1});
     GradientDrawable background = null;
     
-    int backgroundColor = PrefUtils.getIntValue(R.string.PREF_LOGO_BACKGROUND_COLOR, context.getResources().getColor(R.color.pref_logo_background_color_default));
+    int backgroundColor = PrefUtils.getIntValue(R.string.PREF_LOGO_BACKGROUND_COLOR, ContextCompat.getColor(context, R.color.pref_logo_background_color_default));
     
     background = new GradientDrawable(Orientation.BOTTOM_TOP, new int[] {backgroundColor,backgroundColor});
     
@@ -300,7 +301,7 @@ public class SettingConstants {
     logo1.setBounds(maxwidth/2-width/2, maxheight/2-height/2, maxwidth/2+width/2, maxheight/2+height/2);
     
     if(withBorder) {
-      background.setStroke(1, PrefUtils.getIntValue(R.string.PREF_LOGO_BORDER_COLOR, context.getResources().getColor(R.color.pref_logo_border_color_default)));
+      background.setStroke(1, PrefUtils.getIntValue(R.string.PREF_LOGO_BORDER_COLOR, ContextCompat.getColor(context, R.color.pref_logo_border_color_default)));
     }
     
     return logo;

--- a/TV-Browser/src/org/tvbrowser/settings/TimePreference.java
+++ b/TV-Browser/src/org/tvbrowser/settings/TimePreference.java
@@ -11,6 +11,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TimePicker;
 
+import org.tvbrowser.utils.CompatUtils;
+
 public class TimePreference extends DialogPreference {
   private Calendar mTime;
   private TimePicker mTimePicker;
@@ -36,8 +38,8 @@ public class TimePreference extends DialogPreference {
   protected void onBindDialogView(View view) {
     super.onBindDialogView(view);
     
-    mTimePicker.setCurrentHour(mTime.get(Calendar.HOUR_OF_DAY));
-    mTimePicker.setCurrentMinute(mTime.get(Calendar.MINUTE));
+    CompatUtils.setTimePickerHour(mTimePicker, mTime.get(Calendar.HOUR_OF_DAY));
+    CompatUtils.setTimePickerMinute(mTimePicker, mTime.get(Calendar.MINUTE));
   }
   
   @Override
@@ -45,10 +47,10 @@ public class TimePreference extends DialogPreference {
     super.onDialogClosed(positiveResult);
     
     if(positiveResult) {
-      mTime.set(Calendar.HOUR_OF_DAY, mTimePicker.getCurrentHour());
-      mTime.set(Calendar.MINUTE, mTimePicker.getCurrentMinute());
+      mTime.set(Calendar.HOUR_OF_DAY, CompatUtils.getTimePickerHour(mTimePicker));
+      mTime.set(Calendar.MINUTE, CompatUtils.getTimePickerMinute(mTimePicker));
       
-      int minutes = mTimePicker.getCurrentHour() * 60 + mTimePicker.getCurrentMinute();
+      int minutes = CompatUtils.getTimePickerHour(mTimePicker) * 60 + CompatUtils.getTimePickerMinute(mTimePicker);
       
       setTitle(DateFormat.getTimeFormat(getContext()).format(mTime.getTime()));
       

--- a/TV-Browser/src/org/tvbrowser/settings/TvbPreferenceFragment.java
+++ b/TV-Browser/src/org/tvbrowser/settings/TvbPreferenceFragment.java
@@ -30,11 +30,10 @@ import org.tvbrowser.utils.UiUtils;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.Intent;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
-import android.content.res.Resources;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -50,6 +49,7 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 public class TvbPreferenceFragment extends PreferenceFragment implements OnSharedPreferenceChangeListener {
@@ -431,80 +431,81 @@ public class TvbPreferenceFragment extends PreferenceFragment implements OnShare
             if(currentStyle != null && currentStyle.getValue() != null) {
               currentStyleValue = Integer.parseInt(currentStyle.getValue());
             }
-            
+
+            final Context context = getActivity();
             if(currentStyleValue == 1) {
-              int color = getResources().getColor(R.color.pref_color_on_air_background_tvb_style_default);
+              int color = ContextCompat.getColor(context, R.color.pref_color_on_air_background_tvb_style_default);
               onAirBackground.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_on_air_progress_tvb_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_on_air_progress_tvb_style_default);
               onAirProgress.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_tvb_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_tvb_style_default);
               marked.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_favorite_tvb_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_favorite_tvb_style_default);
               markedFavorite.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_reminder_tvb_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_reminder_tvb_style_default);
               markedReminder.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_sync_tvb_style_favorite_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_sync_tvb_style_favorite_default);
               markedSync.setColors(color, color);
               
               
-              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_glow_style_default)) == getResources().getColor(R.color.pref_color_running_time_selection_background_glow_style_default)) {
+              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_glow_style_default)) == ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_glow_style_default)) {
                 Editor edit = (Editor)sharedPreferences.edit();
-                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default));
+                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default));
                 edit.commit();
               }
             }
             else if(currentStyleValue == 2) {
-              int color = getResources().getColor(R.color.pref_color_on_air_background_glow_style_default);
+              int color = ContextCompat.getColor(context, R.color.pref_color_on_air_background_glow_style_default);
               onAirBackground.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_on_air_progress_glow_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_on_air_progress_glow_style_default);
               onAirProgress.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_glow_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_glow_style_default);
               marked.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_favorite_glow_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_favorite_glow_style_default);
               markedFavorite.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_reminder_glow_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_reminder_glow_style_default);
               markedReminder.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_sync_glow_style_favorite_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_sync_glow_style_favorite_default);
               markedSync.setColors(color, color);
               
-              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default)) == getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default)) {
+              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default)) == ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default)) {
                 Editor edit = (Editor)sharedPreferences.edit();
-                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_glow_style_default));
+                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_glow_style_default));
                 edit.commit();
               }
             }
             else if(currentStyleValue == 3) {
-              int color = getResources().getColor(R.color.pref_color_on_air_background_decent_dark_style_default);
+              int color = ContextCompat.getColor(context, R.color.pref_color_on_air_background_decent_dark_style_default);
               onAirBackground.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_on_air_progress_decent_dark_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_on_air_progress_decent_dark_style_default);
               onAirProgress.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_decent_dark_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_decent_dark_style_default);
               marked.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_favorite_decent_dark_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_favorite_decent_dark_style_default);
               markedFavorite.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_reminder_decent_dark_style_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_reminder_decent_dark_style_default);
               markedReminder.setColors(color, color);
-              color = getResources().getColor(R.color.pref_color_mark_sync_decent_dark_style_favorite_default);
+              color = ContextCompat.getColor(context, R.color.pref_color_mark_sync_decent_dark_style_favorite_default);
               markedSync.setColors(color, color);
               
-              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default)) == getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default)) {
+              if(sharedPreferences.getInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default)) == ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default)) {
                 Editor edit = (Editor)sharedPreferences.edit();
-                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), getResources().getColor(R.color.pref_color_running_time_selection_background_decent_dark_style_default));
+                edit.putInt(getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_decent_dark_style_default));
                 edit.commit();
               }
             }
             else if(currentStyleValue == 0) {
-              int color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_ON_AIR_BACKGROUND_USER_DEFINED), getResources().getColor(R.color.pref_color_on_air_background_tvb_style_default));
+              int color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_ON_AIR_BACKGROUND_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_on_air_background_tvb_style_default));
               onAirBackground.setColors(color, color);
-              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_ON_AIR_PROGRESS_USER_DEFINED), getResources().getColor(R.color.pref_color_on_air_progress_tvb_style_default));
+              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_ON_AIR_PROGRESS_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_on_air_progress_tvb_style_default));
               onAirProgress.setColors(color, color);
-              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_MARKED_USER_DEFINED), getResources().getColor(R.color.pref_color_mark_tvb_style_default));
+              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_MARKED_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_mark_tvb_style_default));
               marked.setColors(color, color);
-              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_FAVORITE_USER_DEFINED), getResources().getColor(R.color.pref_color_mark_favorite_tvb_style_default));
+              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_FAVORITE_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_mark_favorite_tvb_style_default));
               markedFavorite.setColors(color, color);
-              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_REMINDER_USER_DEFINED), getResources().getColor(R.color.pref_color_mark_reminder_tvb_style_default));
+              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_REMINDER_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_mark_reminder_tvb_style_default));
               markedReminder.setColors(color, color);
-              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_SYNC_USER_DEFINED), getResources().getColor(R.color.pref_color_mark_sync_tvb_style_favorite_default));
+              color = sharedPreferences.getInt(getString(R.string.PREF_COLOR_SYNC_USER_DEFINED), ContextCompat.getColor(context, R.color.pref_color_mark_sync_tvb_style_favorite_default));
               markedSync.setColors(color, color);
             }
             

--- a/TV-Browser/src/org/tvbrowser/tvbrowser/ActivityFavoriteEdit.java
+++ b/TV-Browser/src/org/tvbrowser/tvbrowser/ActivityFavoriteEdit.java
@@ -27,6 +27,7 @@ import org.tvbrowser.content.TvBrowserContentProvider;
 import org.tvbrowser.filter.CategoryFilter;
 import org.tvbrowser.filter.ChannelFilter;
 import org.tvbrowser.settings.SettingConstants;
+import org.tvbrowser.utils.CompatUtils;
 import org.tvbrowser.utils.IOUtils;
 import org.tvbrowser.utils.UiUtils;
 
@@ -37,6 +38,7 @@ import android.content.Intent;
 import android.content.res.Resources.Theme;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.ActionBarActivity;
 import android.text.Editable;
@@ -96,10 +98,10 @@ public class ActivityFavoriteEdit extends ActionBarActivity implements ChannelFi
     mAttributes = (TextView)findViewById(R.id.activity_edit_favorite_input_id_restriction_attributes);
     mExclusions = (EditText)findViewById(R.id.activity_edit_favorite_input_id_restriction_exclusion);
     
-    int color = getResources().getColor(R.color.abc_primary_text_material_light);
+    int color = ContextCompat.getColor(this, R.color.abc_primary_text_material_light);
     
     if(SettingConstants.IS_DARK_THEME) {
-      color = getResources().getColor(R.color.abc_primary_text_material_dark);
+      color = ContextCompat.getColor(this, R.color.abc_primary_text_material_dark);
     }
     
     mDuration.setTextColor(color);
@@ -232,35 +234,35 @@ public class ActivityFavoriteEdit extends ActionBarActivity implements ChannelFi
       if(mFavorite.getDurationRestrictionMinimum() >= 0) {
         minimumSelected.setChecked(true);
         
-        minimum.setCurrentHour(mFavorite.getDurationRestrictionMinimum() / 60);
-        minimum.setCurrentMinute(mFavorite.getDurationRestrictionMinimum() % 60);
+        CompatUtils.setTimePickerHour(minimum, mFavorite.getDurationRestrictionMinimum() / 60);
+        CompatUtils.setTimePickerMinute(minimum, mFavorite.getDurationRestrictionMinimum() % 60);
       }
       else {
         minimum.setEnabled(false);
-        minimum.setCurrentHour(0);
-        minimum.setCurrentMinute(0);
+        CompatUtils.setTimePickerHour(minimum, 0);
+        CompatUtils.setTimePickerMinute(minimum, 0);
       }
       
       if(mFavorite.getDurationRestrictionMaximum() > 0) {
         maximumSelected.setChecked(true);
         
-        maximum.setCurrentHour(mFavorite.getDurationRestrictionMaximum() / 60);
-        maximum.setCurrentMinute(mFavorite.getDurationRestrictionMaximum() % 60);
+        CompatUtils.setTimePickerHour(maximum, mFavorite.getDurationRestrictionMaximum() / 60);
+        CompatUtils.setTimePickerMinute(maximum, mFavorite.getDurationRestrictionMaximum() % 60);
       }
       else {
         maximum.setEnabled(false);
-        maximum.setCurrentHour(0);
-        maximum.setCurrentMinute(0);
+        CompatUtils.setTimePickerHour(maximum, 0);
+        CompatUtils.setTimePickerMinute(maximum, 0);
       }
     }
     else {
       minimum.setEnabled(false);
-      minimum.setCurrentHour(0);
-      minimum.setCurrentMinute(0);
+      CompatUtils.setTimePickerHour(minimum, 0);
+      CompatUtils.setTimePickerMinute(minimum, 0);
       
       maximum.setEnabled(false);
-      maximum.setCurrentHour(0);
-      maximum.setCurrentMinute(0);
+      CompatUtils.setTimePickerHour(maximum, 0);
+      CompatUtils.setTimePickerMinute(maximum, 0);
     }
     
     minimumSelected.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -286,11 +288,11 @@ public class ActivityFavoriteEdit extends ActionBarActivity implements ChannelFi
         int maximumValue = Favorite.VALUE_RESTRICTION_TIME_DEFAULT;
         
         if(minimumSelected.isChecked()) {
-          minimumValue = minimum.getCurrentHour() * 60 + minimum.getCurrentMinute();
+          minimumValue = CompatUtils.getTimePickerHour(minimum) * 60 + CompatUtils.getTimePickerMinute(minimum);
         }
         
         if(maximumSelected.isChecked()) {
-          maximumValue = maximum.getCurrentHour() * 60 + maximum.getCurrentMinute();
+          maximumValue = CompatUtils.getTimePickerHour(maximum) * 60 + CompatUtils.getTimePickerMinute(maximum);
           
           if(maximumValue == 0) {
             maximumValue = Favorite.VALUE_RESTRICTION_TIME_DEFAULT;
@@ -337,24 +339,24 @@ public class ActivityFavoriteEdit extends ActionBarActivity implements ChannelFi
       
       Calendar current = Calendar.getInstance();
       current.setTime(utc.getTime());
-      
-      from.setCurrentHour(current.get(Calendar.HOUR_OF_DAY));
-      from.setCurrentMinute(current.get(Calendar.MINUTE));
+
+      CompatUtils.setTimePickerHour(from, current.get(Calendar.HOUR_OF_DAY));
+      CompatUtils.setTimePickerMinute(from, current.get(Calendar.MINUTE));
       
       utc.set(Calendar.HOUR_OF_DAY, mFavorite.getTimeRestrictionEnd() / 60);
       utc.set(Calendar.MINUTE, mFavorite.getTimeRestrictionEnd() % 60);
       
       current.setTime(utc.getTime());
-      
-      to.setCurrentHour(current.get(Calendar.HOUR_OF_DAY));
-      to.setCurrentMinute(current.get(Calendar.MINUTE));
+
+      CompatUtils.setTimePickerHour(to, current.get(Calendar.HOUR_OF_DAY));
+      CompatUtils.setTimePickerMinute(to, current.get(Calendar.MINUTE));
     }
     else {
-      from.setCurrentHour(0);
-      from.setCurrentMinute(0);
-      
-      to.setCurrentHour(23);
-      to.setCurrentMinute(59);
+      CompatUtils.setTimePickerHour(from, 0);
+      CompatUtils.setTimePickerMinute(from, 0);
+
+      CompatUtils.setTimePickerHour(to, 23);
+      CompatUtils.setTimePickerMinute(to, 59);
     }
     
     builder.setView(timeSelection);
@@ -363,22 +365,22 @@ public class ActivityFavoriteEdit extends ActionBarActivity implements ChannelFi
       @Override
       public void onClick(DialogInterface dialog, int which) {
         Calendar current = Calendar.getInstance();
-        IOUtils.normalizeTime(current, from.getCurrentHour(), from.getCurrentMinute(), 0);
+        IOUtils.normalizeTime(current, CompatUtils.getTimePickerHour(from), CompatUtils.getTimePickerMinute(from), 0);
         
         Calendar utc = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         utc.setTime(current.getTime());
         
         int start = utc.get(Calendar.HOUR_OF_DAY) * 60 + utc.get(Calendar.MINUTE);
         
-        current.set(Calendar.HOUR_OF_DAY, to.getCurrentHour());
-        current.set(Calendar.MINUTE, to.getCurrentMinute());
+        current.set(Calendar.HOUR_OF_DAY, CompatUtils.getTimePickerHour(to));
+        current.set(Calendar.MINUTE, CompatUtils.getTimePickerMinute(to));
         
         utc.setTime(current.getTime());
         
         int end = utc.get(Calendar.HOUR_OF_DAY) * 60 + utc.get(Calendar.MINUTE);
         
-        final int unNormalizedFromTime = from.getCurrentHour() * 60 + from.getCurrentMinute();
-        final int unNormalizedToTime = to.getCurrentHour() * 60 + to.getCurrentMinute();
+        final int unNormalizedFromTime = CompatUtils.getTimePickerHour(from) * 60 + CompatUtils.getTimePickerMinute(from);
+        final int unNormalizedToTime = CompatUtils.getTimePickerHour(to) * 60 + CompatUtils.getTimePickerMinute(to);
         
         if((unNormalizedToTime == unNormalizedFromTime) || (unNormalizedFromTime == 0 && unNormalizedToTime == 1439)) {
           start = Favorite.VALUE_RESTRICTION_TIME_DEFAULT;

--- a/TV-Browser/src/org/tvbrowser/tvbrowser/FragmentProgramTable.java
+++ b/TV-Browser/src/org/tvbrowser/tvbrowser/FragmentProgramTable.java
@@ -58,6 +58,7 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -908,7 +909,7 @@ public class FragmentProgramTable extends Fragment {
     }
     
     if(SettingConstants.IS_DARK_THEME) {
-      programTableLayout.findViewById(R.id.button_panel).setBackgroundColor(getResources().getColor(R.color.background_material_dark));
+      programTableLayout.findViewById(R.id.button_panel).setBackgroundColor(ContextCompat.getColor(getActivity(), R.color.background_material_dark));
     }
     
     ProgramTableLayoutConstants.initialize(getActivity());

--- a/TV-Browser/src/org/tvbrowser/tvbrowser/ReminderBroadcastReceiver.java
+++ b/TV-Browser/src/org/tvbrowser/tvbrowser/ReminderBroadcastReceiver.java
@@ -44,6 +44,7 @@ import android.graphics.Color;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.format.DateFormat;
 import android.util.Log;
 
@@ -250,9 +251,9 @@ public class ReminderBroadcastReceiver extends BroadcastReceiver {
             builder.setContentInfo(channelName);
             
             if(led) {
-              Log.d("info11", PrefUtils.getIntValue(R.string.PREF_REMINDER_COLOR_LED, context.getResources().getColor(R.color.pref_reminder_color_led_default)) + " " + Color.GREEN + " " + Color.RED + " " + Color.YELLOW);
+              Log.d("info11", PrefUtils.getIntValue(R.string.PREF_REMINDER_COLOR_LED, ContextCompat.getColor(context, R.color.pref_reminder_color_led_default)) + " " + Color.GREEN + " " + Color.RED + " " + Color.YELLOW);
               
-              builder.setLights(PrefUtils.getIntValue(R.string.PREF_REMINDER_COLOR_LED, context.getResources().getColor(R.color.pref_reminder_color_led_default)), 1000, 2000);
+              builder.setLights(PrefUtils.getIntValue(R.string.PREF_REMINDER_COLOR_LED, ContextCompat.getColor(context, R.color.pref_reminder_color_led_default)), 1000, 2000);
             }
             
             java.text.DateFormat mTimeFormat = DateFormat.getTimeFormat(context);

--- a/TV-Browser/src/org/tvbrowser/tvbrowser/TvBrowser.java
+++ b/TV-Browser/src/org/tvbrowser/tvbrowser/TvBrowser.java
@@ -54,6 +54,7 @@ import org.tvbrowser.filter.FilterValuesKeyword;
 import org.tvbrowser.settings.PluginPreferencesActivity;
 import org.tvbrowser.settings.SettingConstants;
 import org.tvbrowser.settings.TvbPreferencesActivity;
+import org.tvbrowser.utils.CompatUtils;
 import org.tvbrowser.utils.IOUtils;
 import org.tvbrowser.utils.PrefUtils;
 import org.tvbrowser.utils.ProgramUtils;
@@ -109,6 +110,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
@@ -273,7 +275,7 @@ public class TvBrowser extends ActionBarActivity implements
   }
   
   private final boolean addUserColor(SharedPreferences pref, Editor edit, int defaultColorKey, int colorKey, int userColorKey) {
-    int defaultColor = getResources().getColor(defaultColorKey);
+    int defaultColor = ContextCompat.getColor(this, defaultColorKey);
     int color = pref.getInt(getString(colorKey), defaultColor);
     
     edit.putInt(getString(userColorKey), color);
@@ -2593,8 +2595,8 @@ public class TvBrowser extends ActionBarActivity implements
       final Set<String> firstDeletedChannels = PrefUtils.getStringSetValue(R.string.PREF_FIRST_DELETED_CHANNELS, new HashSet<String>());
       final Set<String> keptDeletedChannels = PrefUtils.getStringSetValue(R.string.PREF_KEPT_DELETED_CHANNELS, new HashSet<String>());
       
-      final int firstDeletedColor = getResources().getColor(R.color.pref_first_deleted_channels);
-      final int keptDeletedColor = getResources().getColor(R.color.pref_kept_deleted_channels);
+      final int firstDeletedColor = ContextCompat.getColor(this, R.color.pref_first_deleted_channels);
+      final int keptDeletedColor = ContextCompat.getColor(this, R.color.pref_kept_deleted_channels);
       
       // Custom array adapter for channel selection
       final ArrayAdapter<ChannelSelection> channelSelectionAdapter = new ArrayAdapter<ChannelSelection>(TvBrowser.this, R.layout.channel_row, channelSelectionList) {
@@ -3485,15 +3487,15 @@ public class TvBrowser extends ActionBarActivity implements
               
               final TimePicker timePick = (TimePicker)timeSelection.findViewById(R.id.dialog_data_update_selection_auto_update_selection_time);
               timePick.setIs24HourView(DateFormat.is24HourFormat(TvBrowser.this));
-              timePick.setCurrentHour(currentAutoUpdateTime.get()/60);
-              timePick.setCurrentMinute(currentAutoUpdateTime.get()%60);
+              CompatUtils.setTimePickerHour(timePick, currentAutoUpdateTime.get()/60);
+              CompatUtils.setTimePickerMinute(timePick, currentAutoUpdateTime.get()%60);
               
               b2.setView(timeSelection);
               
               b2.setPositiveButton(android.R.string.ok, new OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                  currentAutoUpdateTime.set(timePick.getCurrentHour() * 60 + timePick.getCurrentMinute());
+                  currentAutoUpdateTime.set(CompatUtils.getTimePickerHour(timePick) * 60 + CompatUtils.getTimePickerMinute(timePick));
                   
                   Calendar now = Calendar.getInstance();
                   

--- a/TV-Browser/src/org/tvbrowser/utils/CompatUtils.java
+++ b/TV-Browser/src/org/tvbrowser/utils/CompatUtils.java
@@ -44,6 +44,7 @@ import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.RemoteViews;
+import android.widget.TimePicker;
 
 /**
  * A class that uses the current available method of deprecated methods on the Build.VERSION of the running device.
@@ -220,5 +221,45 @@ public class CompatUtils {
     else {
       return file.isDirectory() && file.getName().toLowerCase(Locale.GERMAN).contains("sdcard");
     }
+  }
+
+  public static void setTimePickerHour(final TimePicker timePicker, final int hour) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M )
+      timePicker.setHour(hour);
+    else
+      //noinspection deprecation
+      timePicker.setCurrentHour(hour);
+  }
+
+  public static int getTimePickerHour(final TimePicker timePicker) {
+    int hour;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      hour = timePicker.getHour();
+    }
+    else {
+      //noinspection deprecation
+      hour = timePicker.getCurrentHour();
+    }
+    return hour;
+  }
+
+  public static void setTimePickerMinute(final TimePicker timePicker, final int minute) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M )
+      timePicker.setMinute(minute);
+    else
+      //noinspection deprecation
+      timePicker.setCurrentMinute(minute);
+  }
+
+  public static int getTimePickerMinute(final TimePicker timePicker) {
+    int minute;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      minute = timePicker.getMinute();
+    }
+    else {
+      //noinspection deprecation
+      minute = timePicker.getCurrentMinute();
+    }
+    return minute;
   }
 }

--- a/TV-Browser/src/org/tvbrowser/utils/IOUtils.java
+++ b/TV-Browser/src/org/tvbrowser/utils/IOUtils.java
@@ -858,6 +858,20 @@ public class IOUtils {
   }
 
   /**
+   * Closes the given database cursor, releases assigned resources, and makes the cursor invalid.
+   * A call to {@link Cursor#requery()} will not make the cursor valid again.
+   * Calls are <code>null</code>-safe and idempotent.
+   *
+   * @param cursor the {@link Cursor} to close.
+   * @see Cursor#close()
+   */
+  public static void close(final Cursor cursor) {
+    if (cursor!=null && !cursor.isClosed()) {
+      cursor.close();
+    }
+  }
+
+  /**
    * Disconnects the given connection and releases or reuses associated resources.
    * Calls are <code>null</code>-safe and idempotent.
    * <p/>

--- a/TV-Browser/src/org/tvbrowser/utils/UiUtils.java
+++ b/TV-Browser/src/org/tvbrowser/utils/UiUtils.java
@@ -81,6 +81,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
+import android.graphics.PixelFormat;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.Typeface;
@@ -327,7 +328,7 @@ public class UiUtils {
                     });
                   }
                   
-                  final int favoriteMatchHighlightColor = PrefUtils.getIntValue(R.string.PREF_DETAIL_HIGHLIGHT_COLOR, context.getResources().getColor(R.color.pref_detail_highlight_color_default));
+                  final int favoriteMatchHighlightColor = PrefUtils.getIntValue(R.string.PREF_DETAIL_HIGHLIGHT_COLOR, ContextCompat.getColor(context, R.color.pref_detail_highlight_color_default));
                   
                   final Favorite[] markedFromFavorites = Favorite.getFavoritesForUniqueId(context, id);
                   final ArrayList<FavoriteTypePattern> patternList = new ArrayList<FavoriteTypePattern>();
@@ -366,7 +367,7 @@ public class UiUtils {
                   final Resources resources = context.getResources();
 
                   if(!SettingConstants.IS_DARK_THEME && !(finish instanceof InfoActivity)) {
-                    date.setTextColor(resources.getColor(R.color.detail_date_channel_color_light));
+                    date.setTextColor(ContextCompat.getColor(context, R.color.detail_date_channel_color_light));
                   }
 
                   final int channelID = c.getInt(c.getColumnIndex(TvBrowserContentProvider.CHANNEL_KEY_CHANNEL_ID));
@@ -401,7 +402,7 @@ public class UiUtils {
 
 	                    BitmapDrawable l = new BitmapDrawable(resources, logo);
 
-	                    int color = PrefUtils.getIntValue(R.string.PREF_LOGO_BACKGROUND_COLOR, resources.getColor(R.color.pref_logo_background_color_default));
+	                    int color = PrefUtils.getIntValue(R.string.PREF_LOGO_BACKGROUND_COLOR, ContextCompat.getColor(context, R.color.pref_logo_background_color_default));
 
 	                    GradientDrawable background = new GradientDrawable(Orientation.BOTTOM_TOP,new int[] {color,color});
 
@@ -409,7 +410,7 @@ public class UiUtils {
 
 	                    if(PrefUtils.getBooleanValue(R.string.PREF_LOGO_BORDER, R.bool.pref_logo_border_default)) {
 	                      add = 3;
-	                      background.setStroke(1, PrefUtils.getIntValue(R.string.PREF_LOGO_BORDER_COLOR, resources.getColor(R.color.pref_logo_border_color_default)));
+	                      background.setStroke(1, PrefUtils.getIntValue(R.string.PREF_LOGO_BORDER_COLOR, ContextCompat.getColor(context, R.color.pref_logo_border_color_default)));
 	                    }
 
 	                    background.setBounds(0, 0, width + add, height + add);
@@ -1581,7 +1582,7 @@ public class UiUtils {
 
     @Override
     public int getOpacity() {
-      return 0;
+      return PixelFormat.UNKNOWN;
     }
 
     @Override
@@ -1903,14 +1904,14 @@ public class UiUtils {
             color = SettingConstants.EXPIRED_LIGHT_COLOR;
           }
           break;
-      case MARKED_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_MARKED), context.getResources().getColor(R.color.pref_color_mark_tvb_style_default));break;
-      case MARKED_FAVORITE_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_FAVORITE), context.getResources().getColor(R.color.pref_color_mark_favorite_tvb_style_default));break;
-      case MARKED_REMINDER_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_REMINDER), context.getResources().getColor(R.color.pref_color_mark_reminder_tvb_style_default));break;
-      case MARKED_SYNC_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_SYNC), context.getResources().getColor(R.color.pref_color_mark_sync_tvb_style_favorite_default));break;
-      case ON_AIR_BACKGROUND_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_ON_AIR_BACKGROUND), context.getResources().getColor(R.color.pref_color_on_air_background_tvb_style_default));break;
-      case ON_AIR_PROGRESS_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_ON_AIR_PROGRESS), context.getResources().getColor(R.color.pref_color_on_air_progress_tvb_style_default));break;
-      case RUNNING_TIME_SELECTION_KEY: color = pref.getInt(context.getString(R.string.PREF_RUNNING_TIME_SELECTION), context.getResources().getColor(R.color.pref_color_running_time_selection_background_tvb_style_default));break;
-      case I_DONT_WANT_TO_SEE_HIGHLIGHT_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_I_DONT_WANT_TO_SEE_HIGHLIGHT_COLOR), context.getResources().getColor(R.color.i_dont_want_to_see_highlight));break;
+      case MARKED_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_MARKED), ContextCompat.getColor(context, R.color.pref_color_mark_tvb_style_default));break;
+      case MARKED_FAVORITE_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_FAVORITE), ContextCompat.getColor(context, R.color.pref_color_mark_favorite_tvb_style_default));break;
+      case MARKED_REMINDER_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_REMINDER), ContextCompat.getColor(context, R.color.pref_color_mark_reminder_tvb_style_default));break;
+      case MARKED_SYNC_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_SYNC), ContextCompat.getColor(context, R.color.pref_color_mark_sync_tvb_style_favorite_default));break;
+      case ON_AIR_BACKGROUND_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_ON_AIR_BACKGROUND), ContextCompat.getColor(context, R.color.pref_color_on_air_background_tvb_style_default));break;
+      case ON_AIR_PROGRESS_KEY: color = pref.getInt(context.getString(R.string.PREF_COLOR_ON_AIR_PROGRESS), ContextCompat.getColor(context, R.color.pref_color_on_air_progress_tvb_style_default));break;
+      case RUNNING_TIME_SELECTION_KEY: color = pref.getInt(context.getString(R.string.PREF_RUNNING_TIME_SELECTION), ContextCompat.getColor(context, R.color.pref_color_running_time_selection_background_tvb_style_default));break;
+      case I_DONT_WANT_TO_SEE_HIGHLIGHT_COLOR_KEY: color = pref.getInt(context.getString(R.string.PREF_I_DONT_WANT_TO_SEE_HIGHLIGHT_COLOR), ContextCompat.getColor(context, R.color.i_dont_want_to_see_highlight));break;
     }
     
     return color;

--- a/TV-Browser/src/org/tvbrowser/view/ProgramPanel.java
+++ b/TV-Browser/src/org/tvbrowser/view/ProgramPanel.java
@@ -32,6 +32,7 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Handler;
+import android.support.v4.content.ContextCompat;
 import android.text.Spannable;
 import android.text.TextPaint;
 import android.view.View;
@@ -201,10 +202,10 @@ public class ProgramPanel extends View {
       
       if(isExpired()) {
         if(SettingConstants.IS_DARK_THEME) {
-          mPicture.setColorFilter(getResources().getColor(org.tvbrowser.tvbrowser.R.color.dark_gray), PorterDuff.Mode.DARKEN);
+          mPicture.setColorFilter(ContextCompat.getColor(getContext(), org.tvbrowser.tvbrowser.R.color.dark_gray), PorterDuff.Mode.DARKEN);
         }
         else {
-          mPicture.setColorFilter(getResources().getColor(android.R.color.darker_gray), PorterDuff.Mode.LIGHTEN);
+          mPicture.setColorFilter(ContextCompat.getColor(getContext(), android.R.color.darker_gray), PorterDuff.Mode.LIGHTEN);
         }
       }
     }
@@ -356,7 +357,7 @@ public class ProgramPanel extends View {
   public void checkExpired(Handler handler) {
     if(!mIsExpired && isExpired()) {
       if(mPicture != null) {
-        mPicture.setColorFilter(getResources().getColor(android.R.color.darker_gray), PorterDuff.Mode.LIGHTEN);
+        mPicture.setColorFilter(ContextCompat.getColor(getContext(), android.R.color.darker_gray), PorterDuff.Mode.LIGHTEN);
       }
       
       handler.post(new Runnable() {

--- a/TV-Browser/src/org/tvbrowser/view/ProgramTableLayoutConstants.java
+++ b/TV-Browser/src/org/tvbrowser/view/ProgramTableLayoutConstants.java
@@ -28,6 +28,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.text.TextPaint;
 import android.text.format.DateFormat;
 import android.widget.TextView;
@@ -148,7 +149,7 @@ public class ProgramTableLayoutConstants {
         
     BLOCK_PAINT.setColor(Color.argb(30,GRAY_VALUE, GRAY_VALUE, GRAY_VALUE));
     LINE_PAINT.setColor(Color.argb(60, GRAY_VALUE, GRAY_VALUE, GRAY_VALUE));
-    CHANNEL_LINE_PAINT.setColor(context.getResources().getColor(R.color.light_gray));
+    CHANNEL_LINE_PAINT.setColor(ContextCompat.getColor(context, R.color.light_gray));
     
     PADDING_SIDE = (int) (2 * scale + 0.5f);
     
@@ -156,7 +157,7 @@ public class ProgramTableLayoutConstants {
     TIME_BLOCK_TIME_PAINT.setColor(new TextView(context).getTextColors().getDefaultColor());
     FONT_SIZE_ASCENT = Math.abs(TIME_BLOCK_TIME_PAINT.getFontMetricsInt().ascent);
     
-    CHANNEL_BACKGROUND_PAINT.setColor(context.getResources().getColor(R.color.prog_table_channel_background));
+    CHANNEL_BACKGROUND_PAINT.setColor(ContextCompat.getColor(context, R.color.prog_table_channel_background));
     CHANNEL_BACKGROUND_PAINT.setStyle(Paint.Style.FILL_AND_STROKE);
     
     TIME_FORMAT = DateFormat.getTimeFormat(context);
@@ -168,7 +169,7 @@ public class ProgramTableLayoutConstants {
     
     CHANNEL_BAR_HEIGHT = context.getResources().getDimensionPixelSize(R.dimen.prog_table_channel_height);
     
-    CHANNEL_PAINT.setColor(context.getResources().getColor(R.color.prog_table_channel_color));
+    CHANNEL_PAINT.setColor(ContextCompat.getColor(context, R.color.prog_table_channel_color));
     CHANNEL_PAINT.setTextSize(context.getResources().getDimensionPixelSize(R.dimen.prog_table_channel_font_size));
     CHANNEL_PAINT.setTypeface(Typeface.DEFAULT_BOLD);
     

--- a/TV-Browser/src/org/tvbrowser/view/SeparatorDrawable.java
+++ b/TV-Browser/src/org/tvbrowser/view/SeparatorDrawable.java
@@ -23,7 +23,9 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
+import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
 
 public class SeparatorDrawable extends Drawable {
   private Paint mLineColor = new Paint();
@@ -37,10 +39,10 @@ public class SeparatorDrawable extends Drawable {
     PrefUtils.initialize(context.getApplicationContext());
     
     mLineColor.setStyle(Paint.Style.STROKE);
-    mLineColor.setColor(PrefUtils.getIntValue(R.string.PREF_COLOR_SEPARATOR_LINE, context.getResources().getColor(R.color.pref_color_separator_line)));
+    mLineColor.setColor(PrefUtils.getIntValue(R.string.PREF_COLOR_SEPARATOR_LINE, ContextCompat.getColor(context, R.color.pref_color_separator_line)));
     
     mDividerColor.setStyle(Paint.Style.FILL_AND_STROKE);
-    mDividerColor.setColor(PrefUtils.getIntValue(R.string.PREF_COLOR_SEPARATOR_SPACE, context.getResources().getColor(R.color.pref_color_separator_space)));
+    mDividerColor.setColor(PrefUtils.getIntValue(R.string.PREF_COLOR_SEPARATOR_SPACE, ContextCompat.getColor(context, R.color.pref_color_separator_space)));
   }
   
   @Override
@@ -56,7 +58,7 @@ public class SeparatorDrawable extends Drawable {
   @Override
   public int getOpacity() {
     // TODO Auto-generated method stub
-    return 0;
+    return PixelFormat.UNKNOWN;
   }
 
   @Override


### PR DESCRIPTION
- Replaced deprecated Context.getResources().getColor(int) by ContextCompat.getColor(Context, int).
- Replaced deprecated TimePicker.setCurrent*(Integer) by CompatUtils.setTimePicker*(TimePicker, int).
- Replaced deprecated TimePicker.getCurrent*() by CompatUtils.getTimePicker*(TimePicker).
- Minor lint error fixes: closing cursors [dedicated method signature], Drawable.getOpacity() must return PixelFormat.UNKNOWN instead of 0.
