### PR TITLE
subpixel rendering for TimeBlockProgramTableLayout + simplified forma…

### DIFF
--- a/TV-Browser/res/values/strings.xml
+++ b/TV-Browser/res/values/strings.xml
@@ -1262,4 +1262,5 @@
     <string name="waiting_detail_show">Opening detail window&#8230;</string>
     <string name="detail_date_format">%1$ta, %2$s %3$s - %4$s, %5$s</string>
     
+    <string name="time_block_time_format" translatable="false">%1$02d</string>
 </resources>

--- a/TV-Browser/src/org/tvbrowser/view/ProgramTableLayoutConstants.java
+++ b/TV-Browser/src/org/tvbrowser/view/ProgramTableLayoutConstants.java
@@ -43,6 +43,9 @@ public class ProgramTableLayoutConstants {
   static final Paint CHANNEL_LINE_PAINT = new Paint();
   
   static final TextPaint TIME_BLOCK_TIME_PAINT = new TextPaint();
+  static {
+    TIME_BLOCK_TIME_PAINT.setFlags(Paint.SUBPIXEL_TEXT_FLAG | Paint.ANTI_ALIAS_FLAG);
+  }
   
   static int FONT_SIZE_ASCENT;
   static int COLUMN_WIDTH = -1;

--- a/TV-Browser/src/org/tvbrowser/view/TimeBlockProgramTableLayout.java
+++ b/TV-Browser/src/org/tvbrowser/view/TimeBlockProgramTableLayout.java
@@ -22,6 +22,8 @@ import java.util.Calendar;
 import android.content.Context;
 import android.graphics.Canvas;
 
+import org.tvbrowser.tvbrowser.R;
+
 public class TimeBlockProgramTableLayout extends ProgramTableLayout {
   //private ArrayList<Integer> mChannelIDsOrdered;
   private int[] mBlockHeights;
@@ -167,13 +169,8 @@ public class TimeBlockProgramTableLayout extends ProgramTableLayout {
       if(time >= 24) {
         time -= 24;
       }
-      
-      String value = String.valueOf(time);
-      
-      if(value.length() == 1) {
-        value = "0" + value;
-      }
-      
+
+      final String value = getContext().getString(R.string.time_block_time_format, time);
       float length = ProgramTableLayoutConstants.TIME_BLOCK_TIME_PAINT.measureText(value);
       
       canvas.drawText(value, ProgramTableLayoutConstants.ROW_HEADER / 2 - length/2, y, ProgramTableLayoutConstants.TIME_BLOCK_TIME_PAINT);


### PR DESCRIPTION
TimeBlockProgramTableLayout:

- Subpixel Rendering/ antialias for fonts in Canvas (left time block hour column)
- Simplified format string to avoid string concatenation

![screenshot_2017-02-25-10-39-56](https://cloud.githubusercontent.com/assets/6201441/23331134/e823db3e-fb5f-11e6-88da-aa2d40c54d42.png)
![screenshot_2017-02-25-10-49-59](https://cloud.githubusercontent.com/assets/6201441/23331135/e824f82a-fb5f-11e6-8a88-05b452ff04c9.png)

