### PR TITLE
Support for voice search via "Ok Google"

### DIFF
--- a/TV-Browser/AndroidManifest.xml
+++ b/TV-Browser/AndroidManifest.xml
@@ -95,6 +95,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="com.google.android.gms.actions.SEARCH_ACTION" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
             <meta-data
                 android:name="android.app.searchable"
                 android:resource="@xml/searchable" />


### PR DESCRIPTION
Support for voice search via "Ok Google", e. g.  "Ok Google, suche Tagesschau in TV-Browser" or "Ok Google, search for Tagesschau on TV-Browser".

Voice search support requires to upload the app to Google Play first, e. g. to the beta stage (to register the manifest changes with Google). The voice open action "Open TV-Browser" or "Öffne TV-Browser" is enabled by default.

Test locally with: adb shell am start -a com.google.android.gms.actions.SEARCH_ACTION -e query Tagesschau