### PR TITLE
Fixes dark text on dark background issue in light  theme + Exception

### DIFF
--- a/TV-Browser/res/layout/activity_tv_browser.xml
+++ b/TV-Browser/res/layout/activity_tv_browser.xml
@@ -1,21 +1,27 @@
-<RelativeLayout
+<android.support.v7.widget.FitWindowsLinearLayout
     android:id="@id/activity_tvbrowser_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".TvBrowser">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:elevation="4dp"
+        android:elevation="4dp">
 
     <android.support.v7.widget.Toolbar
         android:id="@id/activity_tvbrowser_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
         android:background="?attr/colorPrimary"
-        android:elevation="6dp"
         android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        />
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <android.support.design.widget.TabLayout
         android:id="@id/activity_tvbrowser_tabs"
@@ -23,22 +29,14 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/activity_tvbrowser_toolbar"
         android:background="?attr/colorPrimary"
-        android:elevation="6dp"
-        android:minHeight="?attr/actionBarSize"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+
+    </android.support.design.widget.AppBarLayout>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/activity_tvbrowser_pager"
         android:layout_width="match_parent"
-        android:layout_height="fill_parent"
-        android:layout_below="@id/activity_tvbrowser_tabs"/>
+        android:layout_height="fill_parent"/>
 
-</RelativeLayout>
-
-<!--
-<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@id/pager"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".TvBrowser" />-->
+</android.support.v7.widget.FitWindowsLinearLayout>

--- a/TV-Browser/res/values/styles.xml
+++ b/TV-Browser/res/values/styles.xml
@@ -12,16 +12,11 @@
 -->
 
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
-        <item name="android:textViewStyle">@style/MyTextViewStyle</item>
     	<item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     	<item name="ic_back_icon" >@drawable/ic_action_back_light</item>
     	<item name="ic_forward_icon" >@drawable/ic_action_forward_light</item>
     </style>
--->
-    <style name="MyTextViewStyle" parent="android:Widget.TextView">
-    	<item name="android:textColor">@color/text_appcompat_light</item>
-	</style>
     
     <style name="AppDarkTheme" parent="Theme.AppCompat">
         <item name="popupTheme">@style/ThemeOverlay.AppCompat</item>
@@ -63,16 +58,11 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">20sp</item>
     </style>
-    <style name="favorite_add_button_style">
-        
-    </style>
-	<style name="favorite_show_sync_button_style">
-    </style>
     
 	<style name="Divider">
-    <item name="android:layout_width">match_parent</item>
-    <item name="android:layout_height">1dp</item>
-    <item name="android:background">?android:attr/listDivider</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:background">?android:attr/listDivider</item>
 	</style>
 
 	<style name="DetailDialogEntry">

--- a/TV-Browser/src/org/tvbrowser/content/TvBrowserContentProvider.java
+++ b/TV-Browser/src/org/tvbrowser/content/TvBrowserContentProvider.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -824,8 +825,8 @@ public class TvBrowserContentProvider extends ContentProvider {
       path = "";
     }
     else if(!path.endsWith(File.separator)) {
-      path += File.separator;
-    }
+        path += File.separator;
+      }
     Log.d("info11", "DATABASEPATH " + path);
     //path = "";
     mDataBaseHelper = new TvBrowserDataBaseHelper(getContext(), path + DATABASE_TVB_NAME, null, TvBrowserDataBaseHelper.DATABASE_VERSION);
@@ -837,7 +838,7 @@ public class TvBrowserContentProvider extends ContentProvider {
     
     String databasePath = "internal";
     
-    try {
+      try {
       databasePath = pref.getString(getContext().getString(R.string.PREF_DATABASE_PATH), getContext().getString(R.string.pref_database_path_default));
     }catch(NotFoundException ignored) {}
     
@@ -939,12 +940,19 @@ public class TvBrowserContentProvider extends ContentProvider {
         
         // If this is a row query, limit the result set to the pased in row.
         switch(uriMatcher.match(uri)) {
-          case SEARCH: String search = uri.getPathSegments().get(1).replace("'", "''");
-                       qb.appendWhere("(" + DATA_KEY_TITLE + " LIKE '%" + search + "%' OR " + DATA_KEY_EPISODE_TITLE + " LIKE '%" +  search + "%') AND " + DATA_KEY_ENDTIME + ">=" + System.currentTimeMillis() + " AND NOT " + DATA_KEY_DONT_WANT_TO_SEE);
-                       qb.setProjectionMap(SEARCH_PROJECTION_MAP);
-                       qb.setTables(TvBrowserDataBaseHelper.DATA_TABLE);
-                       orderBy = DATA_KEY_STARTTIME;
-                       break;
+          case SEARCH:
+            final List<String> uriPathSegments = uri.getPathSegments();
+            String search = "   ";// SearchManager.SUGGEST_URI_PATH_QUERY;
+            if (uriPathSegments != null) {
+              if (uriPathSegments.size() > 1) {
+                search = uriPathSegments.get(1).replace("'", "''").trim();
+              }
+            }
+            qb.appendWhere("(" + DATA_KEY_TITLE + " LIKE '%" + search + "%' OR " + DATA_KEY_EPISODE_TITLE + " LIKE '%" + search + "%') AND " + DATA_KEY_ENDTIME + ">=" + System.currentTimeMillis() + " AND NOT " + DATA_KEY_DONT_WANT_TO_SEE);
+            qb.setProjectionMap(SEARCH_PROJECTION_MAP);
+            qb.setTables(TvBrowserDataBaseHelper.DATA_TABLE);
+            orderBy = DATA_KEY_STARTTIME;
+            break;
           case GROUP_ID: qb.appendWhere(KEY_ID + "=" + uri.getPathSegments().get(1));
           case GROUPS: qb.setTables(TvBrowserDataBaseHelper.GROUPS_TABLE);
                        orderBy = GROUP_KEY_GROUP_ID;break;

--- a/TV-Browser/src/org/tvbrowser/tvbrowser/TvBrowser.java
+++ b/TV-Browser/src/org/tvbrowser/tvbrowser/TvBrowser.java
@@ -111,7 +111,6 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.util.SparseArrayCompat;
-import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -189,7 +188,6 @@ public class TvBrowser extends AppCompatActivity {
   private boolean updateRunning;
   private boolean selectingChannels;
   private TabLayout mTabLayout;
-  //private ActionBar actionBar;
   private boolean mSearchExpanded;
 
   /**
@@ -4779,12 +4777,9 @@ public class TvBrowser extends AppCompatActivity {
     getMenuInflater().inflate(R.menu.tv_browser, menu);
 
     //  Associate searchable configuration with the SearchView
-    SearchManager searchManager =
-           (SearchManager) getSystemService(Context.SEARCH_SERVICE);
-    SearchView searchView =
-            (SearchView) menu.findItem(R.id.search).getActionView();
-    searchView.setSearchableInfo(
-            searchManager.getSearchableInfo(getComponentName()));
+    SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
+    SearchView searchView = (SearchView) menu.findItem(R.id.search).getActionView();
+    searchView.setSearchableInfo(searchManager.getSearchableInfo(getComponentName()));
 
     mUpdateItem = menu.findItem(R.id.menu_tvbrowser_action_update_data);
 
@@ -4864,7 +4859,7 @@ public class TvBrowser extends AppCompatActivity {
   @SuppressLint("NewApi")
   private void addOnActionExpandListener(MenuItem search) {
     if(search != null) {
-      MenuItemCompat.setOnActionExpandListener(search, new MenuItemCompat.OnActionExpandListener() {
+      search.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
         @Override
         public boolean onMenuItemActionExpand(MenuItem item) {
           mSearchExpanded = true;


### PR DESCRIPTION
- Fixes dark text on dark background issue in light  theme (search view result dropdown)
- Fixes index out of bounds exception in TvBrowserContentProvider (no query on index 1 on first action expand)
- Removes MenuItemCompat due deprecation (search action)
- Tested with SDK 15 (4.0.x) . and SDK 27 (8.1)

![port_back](https://user-images.githubusercontent.com/6201441/42100859-e8e9aaf8-7bb0-11e8-8ca8-8c27c3a45b88.png)

https://stackoverflow.com/questions/29853155/styling-appcompat-searchview-with-appcompat-22-1-0-is-not-working/29870699
